### PR TITLE
Run pytest against current directory, not tests directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Run tests"
         run: |
-          pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests tests/ --cov-report=xml
+          pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests . --cov-report=xml
 
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v4"


### PR DESCRIPTION
In case we ever add tests for e.g. README or docs with sybil