### PR TITLE
Add Claude Code LSP plugin for Python

### DIFF
--- a/.claude/plugins/pyright-lsp/.claude-plugin/plugin.json
+++ b/.claude/plugins/pyright-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "pyright-lsp",
+  "description": "Python language server using Pyright",
+  "version": "1.0.0"
+}

--- a/.claude/plugins/pyright-lsp/.lsp.json
+++ b/.claude/plugins/pyright-lsp/.lsp.json
@@ -1,0 +1,11 @@
+{
+  "python": {
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python",
+      ".pyi": "python"
+    },
+    "transport": "stdio"
+  }
+}


### PR DESCRIPTION
## Summary
- Add pyright LSP plugin for Claude Code at project scope
- Located in `.claude/plugins/pyright-lsp/`

## Configuration
- Plugin uses pyright-langserver for Python language support
- Configured for `.py` and `.pyi` files

## Test plan
- Ensure pyright-langserver is installed
- Set `ENABLE_LSP_TOOL=1` environment variable
- Start Claude Code in the repository

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a project-scoped Claude Code LSP plugin for Python using Pyright.
> 
> - Introduces `/.claude/plugins/pyright-lsp/` with `plugin.json` metadata
> - Configures `.lsp.json` to run `pyright-langserver --stdio` with `.py`/`.pyi` mapping via stdio transport
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358bd2b09e5d790428f20cbe3652fed295902ec9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->