### PR TITLE
Add pyrefly and pyrefly-docs configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,8 @@ ci:
     - vulture
     - vulture-docs
     - yamlfix
+    - pyrefly
+    - pyrefly-docs
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
@@ -374,3 +376,21 @@ repos:
         types_or: [rst]
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
+
+      - id: pyrefly
+        name: pyrefly
+        stages: [pre-push]
+        entry: uv run --extra=dev pyrefly check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyrefly-docs
+        name: pyrefly-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyrefly check"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ optional-dependencies.dev = [
     "pre-commit==4.5.1",
     "pylint[spelling]==4.0.4",
     "pyproject-fmt==2.11.1",
+    "pyrefly==0.46.1",
     "pyright==1.1.407",
     "pyroma==5.0.1",
     "pytest==9.0.2",


### PR DESCRIPTION
Add pyrefly type checker and pyrefly-docs hooks to pre-commit configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds type-checking via `pyrefly` to the workflow.
> 
> - New pre-push hooks: `pyrefly` (`uv run ... pyrefly check`) and `pyrefly-docs` (via `doccmd` running `pyrefly check`)
> - Add `pyrefly==0.46.1` to `dev` optional dependencies in `pyproject.toml`
> - Update CI skip list to include `pyrefly` and `pyrefly-docs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7deeb7cf3e61f5c04aa7e00cc78f28f9765aff1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->