### PR TITLE
Make zizmor collection strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -372,7 +372,7 @@ repos:
 
       - id: zizmor
         name: zizmor
-        entry: uv run --extra=dev zizmor .github
+        entry: uv run --extra=dev zizmor --strict-collection .github
         language: python
         pass_filenames: false
         types_or: [yaml]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens the `zizmor` pre-commit hook configuration.
> 
> - Updates `.pre-commit-config.yaml` to run `zizmor` with `--strict-collection` against `.github`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b1078d5dc752f2553928a841e29ac64c4ac459c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->