### PR TITLE
Fix block scalar newline interpretation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n"
+          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
+            \ }}\n"
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
The previous fix used a YAML block scalar (`|-`) which doesn't interpret `\n` as newlines, causing literal `\n` to appear in CHANGELOG.rst. This fix uses a double-quoted string on a single line which correctly interprets escape sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `\n` escapes are interpreted as newlines when updating `CHANGELOG.rst` during releases.
> 
> - In `.github/workflows/release.yml`, updates the `Update changelog` step to use a double-quoted `replace` string: `"Next\n----\n\n
> aaaa...\n"` (with interpolations), replacing the previous block scalar form so inserted version headers/underlines render correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 079e3e0e72b327bddf498d8319416e660b1c2a3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->