### PR TITLE
Fix: Remove --example-workers 0 only from mypy-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,6 +154,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
 
+      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]


### PR DESCRIPTION
The previous PR incorrectly removed `--example-workers 0` from all hooks.

This PR reverts that and correctly removes it only from the `mypy-docs` hook, which is the one affected by the mypy bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns docs lint/type-check hooks to use consistent `doccmd` execution settings.
> 
> - Re-adds `--example-workers 0` to `shellcheck-docs`, `pyright-docs`, `ty-docs`, `vulture-docs`, `pylint-docs`, `interrogate-docs`, and `pyrefly-docs`
> - Keeps `mypy-docs` using `doccmd` without `--example-workers 0` (explicit comment references mypy bug)
> - No source code changes; only `.pre-commit-config.yaml` updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit addd51eb73f177554614479b21ef813f13854f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->