### PR TITLE
Bump pyproject-fmt to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ optional-dependencies.dev = [
     "prek==0.3.2",
     "pydocstringformatter==0.7.5",
     "pylint[spelling]==4.0.4",
-    "pyproject-fmt==2.12.1",
+    "pyproject-fmt==2.14.0",
     "pyrefly==0.51.1",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -59,10 +59,6 @@ optional-dependencies.dev = [
     "pytest-cov==7.0.0",
     "pytest-regressions==2.9.1",
     "ruff==0.15.0",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx==9.1.0",
     "sphinx-click==6.2.0",
@@ -74,6 +70,10 @@ optional-dependencies.dev = [
     "ty==0.0.15",
     "types-pyyaml==6.0.12.20250915",
     "vulture==2.14",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
@@ -84,22 +84,17 @@ scripts.vws-web-tools = "vws_web_tools:vws_web_tools_group"
 
 [tool.setuptools]
 zip-safe = false
-
-[tool.setuptools.package-data]
-vws_web_tools = [
+package-data.vws_web_tools = [
     "py.typed",
 ]
-
-[tool.setuptools.packages.find]
-where = [
+packages.find.where = [
     "src",
 ]
 
-[tool.distutils.bdist_wheel]
-universal = true
+[tool.distutils]
+bdist_wheel.universal = true
 
 [tool.setuptools_scm]
-
 # This keeps the start of the version the same as the last release.
 # This is useful for our documentation to include e.g. binary links
 # to the latest released binary.
@@ -109,36 +104,31 @@ version_scheme = "post-release"
 
 [tool.ruff]
 line-length = 79
-
 lint.select = [
     "ALL",
 ]
-
 lint.ignore = [
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
-    "D212",
-    "D415",
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
     # Ruff warns that this conflicts with the formatter.
     "ISC001",
+    "D212",
+    "D415",
 ]
-
 lint.per-file-ignores."doccmd_*.py" = [
+    # Allow asserts in docs.
+    "S101",
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
-    # Allow asserts in docs.
-    "S101",
 ]
-
 lint.per-file-ignores."tests/*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",
 ]
-
 # Do not automatically remove commented out code.
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
@@ -148,21 +138,13 @@ lint.unfixable = [
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
-
-[tool.pylint.'FORMAT']
-
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
-single-line-if-stmt = false
-
-[tool.pylint.'MASTER']
-
+"FORMAT".single-line-if-stmt = false
 # Pickle collected data for later comparisons.
-persistent = true
-
+"MASTER".persistent = true
 # Use multiple processes to speed up Pylint.
-jobs = 0
-
+"MASTER".jobs = 0
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 # See https://chezsoi.org/lucas/blog/pylint-strict-base-configuration.html.
@@ -171,7 +153,7 @@ jobs = 0
 # - pylint.extensions.magic_value
 # - pylint.extensions.while_used
 # as they seemed to get in the way.
-load-plugins = [
+"MASTER".load-plugins = [
     "pylint.extensions.bad_builtin",
     "pylint.extensions.comparison_placement",
     "pylint.extensions.consider_refactoring_into_while_condition",
@@ -188,18 +170,14 @@ load-plugins = [
     "pylint.extensions.set_membership",
     "pylint.extensions.typing",
 ]
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension = false
-
-[tool.pylint.'MESSAGES CONTROL']
-
+"MASTER".unsafe-load-any-extension = false
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable = [
+"MESSAGES CONTROL".enable = [
     "bad-inline-option",
     "deprecated-pragma",
     "file-ignored",
@@ -207,7 +185,6 @@ enable = [
     "use-symbolic-message-instead",
     "useless-suppression",
 ]
-
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -217,8 +194,7 @@ enable = [
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-
-disable = [
+"MESSAGES CONTROL".disable = [
     "too-few-public-methods",
     "too-many-locals",
     "too-many-arguments",
@@ -240,22 +216,16 @@ disable = [
     # Let ruff handle imports
     "wrong-import-order",
 ]
-
-[tool.pylint.'SPELLING']
-
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
-spelling-dict = 'en_US'
-
+"SPELLING".spelling-dict = "en_US"
 # A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file = 'spelling_private_dict.txt'
-
+"SPELLING".spelling-private-dict-file = "spelling_private_dict.txt"
 # Tells whether to store unknown words to indicated private dictionary in
 # --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words = 'no'
+"SPELLING".spelling-store-unknown-words = "no"
 
 [tool.check-manifest]
-
 ignore = [
     ".checkmake-config.ini",
     ".prettierrc",
@@ -295,22 +265,17 @@ indent = 4
 keep_full_version = true
 max_supported_python = "3.14"
 
-[tool.pytest.ini_options]
+[tool.pytest]
+ini_options.xfail_strict = true
+ini_options.log_cli = true
 
-xfail_strict = true
-log_cli = true
-
-[tool.coverage.report]
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
-
-[tool.coverage.run]
-
-branch = true
+run.branch = true
 
 [tool.mypy]
-
 strict = true
 files = [ "." ]
 exclude = [ "build" ]
@@ -336,7 +301,6 @@ omit-covered-files = true
 verbose = 2
 
 [tool.doc8]
-
 max_line_length = 2000
 ignore_path = [
     "./.eggs",
@@ -384,7 +348,6 @@ ignore_names = [
     "templates_path",
     "warning_is_error",
 ]
-
 # Duplicate some of .gitignore
 exclude = [ ".venv" ]
 


### PR DESCRIPTION
## Summary
- Work around tox-dev/toml-fmt#184 (double quotes in comments corrupt arrays) and tox-dev/toml-fmt#186 (single-quoted strings in arrays with comments get corrupted) by adjusting quote style
- Bump pyproject-fmt from the current version to 2.14.0
- Apply new formatting from pyproject-fmt 2.14.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change primarily consisting of formatting/section reshaping; low risk aside from potential tooling behavior differences if any consumer expects the old TOML layout.
> 
> **Overview**
> Updates the dev dependency `pyproject-fmt` to `2.14.0` and reapplies its formatting across `pyproject.toml`.
> 
> This is largely a non-functional reformat: normalizes quoting and comment placement, and restructures several tool sections into dotted-key form (e.g., `tool.setuptools`/`tool.distutils`, `tool.pytest`, `tool.coverage`, and `tool.pylint` subsections).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97ff973e5b11d4f6a36a958825fb7f2da2cbd108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->