### PR TITLE
Bump pyproject-fmt to 2.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ optional-dependencies.dev = [
     "prek==0.3.2",
     "pydocstringformatter==0.7.5",
     "pylint[spelling]==4.0.4",
-    "pyproject-fmt==2.14.0",
+    "pyproject-fmt==2.14.2",
     "pyrefly==0.51.1",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -59,6 +59,10 @@ optional-dependencies.dev = [
     "pytest-cov==7.0.0",
     "pytest-regressions==2.9.1",
     "ruff==0.15.0",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx==9.1.0",
     "sphinx-click==6.2.0",
@@ -70,10 +74,6 @@ optional-dependencies.dev = [
     "ty==0.0.15",
     "types-pyyaml==6.0.12.20250915",
     "vulture==2.14",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
@@ -108,22 +108,22 @@ lint.select = [
     "ALL",
 ]
 lint.ignore = [
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
     "D212",
     "D415",
+    # Ruff warns that this conflicts with the formatter.
+    "ISC001",
 ]
 lint.per-file-ignores."doccmd_*.py" = [
-    # Allow asserts in docs.
-    "S101",
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
+    # Allow asserts in docs.
+    "S101",
 ]
 lint.per-file-ignores."tests/*.py" = [
     # Allow 'assert' as we use it for tests.


### PR DESCRIPTION
Bump pyproject-fmt from 2.14.0 to 2.14.2 and re-format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump and configuration reformatting only; no runtime code or security-sensitive logic is changed.
> 
> **Overview**
> Bumps the dev dependency `pyproject-fmt` from `2.14.0` to `2.14.2`.
> 
> Applies the formatter’s output to `pyproject.toml`, including reordering a few entries/comments (notably around `shellcheck-py`) and minor reshuffling within `ruff` ignore/per-file-ignore lists with no functional behavior change intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df0be1400021e76beb4b2b342fc8d9c216ac3a6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->