### PR TITLE
Update pyproject-fmt to 2.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ optional-dependencies.dev = [
     "prek==0.3.2",
     "pydocstringformatter==0.7.5",
     "pylint[spelling]==4.0.4",
-    "pyproject-fmt==2.14.2",
+    "pyproject-fmt==2.15.2",
     "pyrefly==0.52.0",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -270,10 +270,10 @@ ini_options.xfail_strict = true
 ini_options.log_cli = true
 
 [tool.coverage]
+run.branch = true
 report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
-run.branch = true
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Update pyproject-fmt to 2.15.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tool version bump plus a config ordering/formatting tweak in `pyproject.toml`; no runtime code paths or production dependencies are affected.
> 
> **Overview**
> Bumps the dev dependency `pyproject-fmt` from `2.14.2` to `2.15.2`.
> 
> Also adjusts `pyproject.toml` formatting by moving `coverage`’s `run.branch = true` to match the tool’s expected ordering, with no functional configuration change intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f359c311e0aecfbf87456abd7cb39dc1be92fce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->