### PR TITLE
Matrix lint workflow by hook stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
+        hook-stage: [pre-commit, pre-push, manual]
 
     runs-on: ${{ matrix.platform }}
 
@@ -37,10 +38,8 @@ jobs:
         # Use bash to ensure the step fails if any command fails.
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
-        run: |
-          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
+        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
+          --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Refactor the lint workflow to parallelize hook stage execution by adding `hook-stage` to the build matrix. This runs all three hook stages (pre-commit, pre-push, manual) in parallel instead of sequentially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts CI execution structure without affecting runtime code; main risk is longer/greater job fan-out and potential matrix misconfiguration.
> 
> **Overview**
> Refactors the GitHub Actions CI linting to **matrix** over `hook-stage` (`pre-commit`, `pre-push`, `manual`) so each stage runs as a separate job instead of sequential commands.
> 
> The lint step now executes a single `prek run` using `${{ matrix.hook-stage }}`, increasing parallelism while keeping the same Python/platform test matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2235a012e9779b7d0241d729eee451dee2a2c83e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->