### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
 ]


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only rename affecting how `deptry` interprets dev dependency groups, with no runtime code changes.
> 
> **Overview**
> Updates `pyproject.toml` to rename deptry’s dev dependency groups setting from `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups`, aligning the project with deptry 0.25+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61963c54afcc30ed42c10c298be3845735878ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->