### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "ruff==0.15.11",
@@ -106,6 +106,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "ruff==0.15.11",
@@ -77,12 +78,14 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-web-tools/"
 urls.Source = "https://github.com/VWS-Python/vws-web-tools"
 scripts.vws-web-tools = "vws_web_tools:vws_web_tools_group"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -364,6 +367,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
+    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-web-tools/"
@@ -326,7 +327,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",
@@ -364,3 +364,6 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 import os
 
 import pytest
-from beartype import beartype
 
 from tests.credentials import VWSCredentials
 
@@ -15,16 +14,3 @@ def fixture_vws_credentials() -> VWSCredentials:
         email_address=os.environ["VWS_EMAIL_ADDRESS"],
         password=os.environ["VWS_PASSWORD"],
     )
-
-
-@beartype
-def pytest_collection_modifyitems(
-    session: pytest.Session,
-    config: pytest.Config,
-    items: list[pytest.Item],
-) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    del session, config
-    for item in items:
-        assert isinstance(item, pytest.Function)
-        item.obj = beartype(obj=item.obj)


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes test-time type checking wiring by delegating `@beartype` application to an external pytest plugin, so impact is limited to how tests are collected/executed.
> 
> **Overview**
> Moves beartype enforcement for tests from a custom `pytest_collection_modifyitems` hook in `tests/conftest.py` to the `pytest-beartype-tests` plugin.
> 
> Adds `pytest-beartype-tests` as a dev dependency (with a `uv` git source pin) and removes the now-redundant local `beartype` import/hook, plus drops the related Vulture ignore entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573dbe79e1ef1fca27d3c8d1150ae808c3e82f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->