### PR TITLE
Pin pytest-beartype-tests to 2026.4.20 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "ruff==0.15.11",
@@ -108,7 +108,6 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,6 @@ bdist_wheel.universal = true
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [


### PR DESCRIPTION
Replace the temporary `[tool.uv.sources]` git pin to bc81d99 with the published PyPI release `pytest-beartype-tests==2026.4.20` (same Sybil-safe behavior).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes dev/test dependency sourcing (git pin to PyPI version) in `pyproject.toml`, with no runtime code impact.
> 
> **Overview**
> Switches `pytest-beartype-tests` from an unpinned dependency (previously sourced via a `[tool.uv]` git `rev`) to the published PyPI package `pytest-beartype-tests==2026.4.20`.
> 
> This removes the `[tool.uv.sources]` override entirely, making dev dependency resolution rely on standard package indexing instead of a repository pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6478132e3e99e5f02295c07a6c4ca2b692d8512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->