### PR TITLE
chore: define uv version once in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -110,7 +111,8 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck
@@ -118,7 +120,8 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -127,7 +130,8 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt
@@ -135,7 +139,8 @@ repos:
         entry: shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -144,7 +149,8 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: mypy
@@ -154,7 +160,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
@@ -170,7 +177,8 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright
         name: pyright
@@ -179,7 +187,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright-docs
         name: pyright-docs
@@ -188,7 +197,8 @@ repos:
           --command="pyright"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -199,7 +209,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: ty
         name: ty
@@ -208,7 +219,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: ty-docs
         name: ty-docs
@@ -217,7 +229,8 @@ repos:
           --command="ty check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: vulture
         name: vulture
@@ -225,7 +238,8 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: vulture-docs
@@ -234,7 +248,8 @@ repos:
           --command="vulture"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyroma
@@ -243,7 +258,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [toml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: deptry
@@ -251,7 +267,8 @@ repos:
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pylint
@@ -260,7 +277,8 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pylint-docs
         name: pylint-docs
@@ -275,7 +293,8 @@ repos:
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-check-fix-docs
@@ -283,7 +302,8 @@ repos:
         entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -291,7 +311,8 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix-docs
@@ -300,7 +321,8 @@ repos:
           format"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: doc8
@@ -308,7 +330,8 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: interrogate
@@ -316,7 +339,8 @@ repos:
         entry: uv run --extra=dev -m interrogate
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: interrogate-docs
@@ -325,7 +349,8 @@ repos:
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -344,7 +369,8 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: spelling
         name: spelling
@@ -354,7 +380,8 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: docs
         name: Build Documentation
@@ -362,14 +389,16 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: zizmor
@@ -378,7 +407,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -386,7 +416,8 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyrefly
@@ -396,7 +427,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyrefly-docs
         name: pyrefly-docs
@@ -405,4 +437,5 @@ repos:
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+.uv_version: &uv_version uv==0.9.5
+
 # We use system Python, with required dependencies specified in pyproject.toml.
 # We therefore cannot use those dependencies in pre-commit CI.
 ci:
@@ -100,7 +102,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -108,7 +110,7 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck
@@ -116,7 +118,7 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -125,7 +127,7 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt
@@ -133,7 +135,7 @@ repos:
         entry: shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -142,7 +144,7 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: mypy
@@ -152,7 +154,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
@@ -168,7 +170,7 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright
         name: pyright
@@ -177,7 +179,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright-docs
         name: pyright-docs
@@ -186,7 +188,7 @@ repos:
           --command="pyright"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -197,7 +199,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: ty
         name: ty
@@ -206,7 +208,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: ty-docs
         name: ty-docs
@@ -215,7 +217,7 @@ repos:
           --command="ty check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: vulture
         name: vulture
@@ -223,7 +225,7 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: vulture-docs
@@ -232,7 +234,7 @@ repos:
           --command="vulture"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyroma
@@ -241,7 +243,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [toml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: deptry
@@ -249,7 +251,7 @@ repos:
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pylint
@@ -258,7 +260,7 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pylint-docs
         name: pylint-docs
@@ -273,7 +275,7 @@ repos:
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-check-fix-docs
@@ -281,7 +283,7 @@ repos:
         entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -289,7 +291,7 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix-docs
@@ -298,7 +300,7 @@ repos:
           format"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: doc8
@@ -306,7 +308,7 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: interrogate
@@ -314,7 +316,7 @@ repos:
         entry: uv run --extra=dev -m interrogate
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: interrogate-docs
@@ -323,7 +325,7 @@ repos:
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -342,7 +344,7 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: spelling
         name: spelling
@@ -352,7 +354,7 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: docs
         name: Build Documentation
@@ -360,14 +362,14 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: zizmor
@@ -376,7 +378,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -384,7 +386,7 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyrefly
@@ -394,7 +396,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyrefly-docs
         name: pyrefly-docs
@@ -403,4 +405,4 @@ repos:
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]


### PR DESCRIPTION
Matches the pattern from [literalizer](https://github.com/adamtheturtle/literalizer): a YAML anchor `.uv_version` so the uv pin is declared once and referenced as `*uv_version` in each hook's `additional_dependencies`.

`pre-commit validate-config` may warn about an unexpected root key `.uv_version`; that is expected and matches literalizer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only refactor that should not change behavior, but YAML anchors/extra root key may affect strict config validators.
> 
> **Overview**
> Introduces a single `.uv_version` YAML anchor in `.pre-commit-config.yaml` and replaces repeated `additional_dependencies: [uv==0.9.5]` entries with references to `[*uv_version]` across all local hooks.
> 
> This centralizes the `uv` pin to reduce duplication and make future version bumps a one-line change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94d0c9fff7eef20aa9aa414ef8f100cedfc07774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->