### PR TITLE
fix: wait for Generate button to be enabled in Add Database dialog

### DIFF
--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -368,13 +368,13 @@ def _open_add_database_dialog(
 @beartype
 def _submit_add_database_dialog(
     *,
-    driver: WebDriver,
     wait: WebDriverWait[WebDriver],
 ) -> None:
     """Click the generate button and wait for the dialog to close."""
-    generate_button = driver.find_element(
-        by=By.ID,
-        value="generate-btn",
+    generate_button = wait.until(
+        method=expected_conditions.element_to_be_clickable(
+            mark=(By.ID, "generate-btn"),
+        ),
     )
     generate_button.click()
     wait.until(
@@ -422,7 +422,7 @@ def create_cloud_database(
         text=license_name,
     )
 
-    _submit_add_database_dialog(driver=driver, wait=wait)
+    _submit_add_database_dialog(wait=wait)
 
 
 @_TIMEOUT_RETRY_DECORATOR
@@ -444,7 +444,7 @@ def create_vumark_database(
     )
     database_type_radio_element.click()
 
-    _submit_add_database_dialog(driver=driver, wait=wait)
+    _submit_add_database_dialog(wait=wait)
 
 
 @_TIMEOUT_RETRY_DECORATOR


### PR DESCRIPTION
## Summary
- Wait for the Generate button to be clickable before clicking it in `_submit_add_database_dialog`. The button is briefly disabled while the dialog revalidates after the VuMark radio is selected, so the previous immediate click was a silent no-op and `staleness_of` timed out — failing all VuMark tests on the scheduled CI runs. Cloud DB tests passed because the license-dropdown interaction provided enough delay.

## Test plan
- [x] `test_create_vumark_database_library` passes locally
- [ ] Scheduled CI run goes green (cloud + license tests already passed; the fix shares the same submission path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change confined to Selenium UI automation; it replaces an immediate click with an explicit clickability wait to avoid timing-related test failures.
> 
> **Overview**
> Fixes flaky database creation automation by waiting for the Add Database dialog’s `Generate` button to become *clickable* before clicking it.
> 
> `_submit_add_database_dialog` now uses `WebDriverWait.until(element_to_be_clickable)` (and drops the direct `driver.find_element` usage), and call sites in `create_cloud_database` and `create_vumark_database` are updated to pass only the `wait` object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4cf9d796e3260ec8c0dd02784a0740aa6be6e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->