### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.dev = [
     "doccmd==2026.3.26.2",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.10",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates a dev-only type-checking dependency, but may cause new/changed type errors in CI due to mypy behavior changes.
> 
> **Overview**
> Bumps the dev dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml` (no runtime dependency changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91aa3f3e48d41dcd5939d41aa48da311c2046132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->