### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -167,7 +167,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- Configure the `mypy` pre-push hook to run with 4 parallel workers via `--num-workers=4`.
- Update `mypy-docs` so worker configuration lives inside the `doccmd --command` invocation (`mypy --num-workers=4`) instead of doccmd top-level args.
- Keep hook formatting consistent with existing YAML style.

## Test plan
- [x] Run `pre-commit run --hook-stage pre-push mypy-docs --all-files`
- [x] Run repository commit hooks during `git commit`
- [x] Run repository push hooks during `git push`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-push `mypy`/`mypy-docs` hook invocation flags to enable parallel workers, affecting developer tooling performance rather than runtime behavior.
> 
> **Overview**
> Speeds up pre-push type checking by running `mypy` with `--num-workers=4`.
> 
> Updates the `mypy-docs` hook to pass the worker flag inside the `doccmd --command` string (i.e., `mypy --num-workers=4`) to keep argument handling and YAML formatting consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0509ec2f6a24742c9b27aa0433ec6125facf16c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->