### PR TITLE
[codex] Expose Model Target Web API details

### DIFF
--- a/newsfragments/1390.change
+++ b/newsfragments/1390.change
@@ -1,0 +1,2 @@
+Add ``get_model_target_web_api_details`` to generate OAuth2 credentials
+for Model Target Web API tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,6 +378,9 @@ ignore_names = [
     # pytest configuration
     "pytest_collect_file",
     "pytest_plugins",
+    # public API used by downstream secret generation
+    "cad_data_url",
+    "get_model_target_web_api_details",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",
     # Sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,10 @@ lint.per-file-ignores."tests/*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [
+    # Vulture.
+    "V",
+]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "beartype>=0.22.9",
     "click>=8.1.7",
     "pyyaml>=6.0.2",
+    "requests>=2.34.2",
     "selenium>=4.25.0",
     "tenacity>=9.0.0",
 ]

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,3 +1,5 @@
+DOM
+OAuth
 SVG
 XPath
 beartype
@@ -5,6 +7,7 @@ changelog
 cli
 macOS
 mypy
+noqa
 pragma
 pyright
 reportUnknownMemberType

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1121,12 +1121,16 @@ def _requests_session_from_driver(
 ) -> requests.Session:
     """Create a requests session using the browser's authenticated cookies."""
     session = requests.Session()
+    # This ignore can be removed after Selenium releases script result typing:
+    # https://github.com/SeleniumHQ/selenium/pull/17536
     user_agent = driver.execute_script(  # pyright: ignore[reportUnknownMemberType]
         "return navigator.userAgent",
     )
     if isinstance(user_agent, str):
         session.headers.update({"User-Agent": user_agent})
 
+    # This ignore can be removed after Selenium cookie typing is released:
+    # https://github.com/SeleniumHQ/selenium/pull/17537
     raw_cookies: Any = driver.get_cookies()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     cookies: object = raw_cookies
     if not _is_json_array(cookies):

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1144,11 +1144,15 @@ def _requests_session_from_driver(
 
         domain = cookie.get("domain")
         path = cookie.get("path")
+        cookie_kwargs = {
+            "path": path if isinstance(path, str) else "/",
+        }
+        if isinstance(domain, str):
+            cookie_kwargs["domain"] = domain
         session.cookies.set(
             name=name,
             value=value,
-            domain=domain if isinstance(domain, str) else None,
-            path=path if isinstance(path, str) else "/",
+            **cookie_kwargs,
         )
 
     return session

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -2,10 +2,11 @@
 
 import contextlib
 import datetime
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, TypeGuard
 from urllib.parse import urlparse
 
 import click
@@ -1056,16 +1057,19 @@ def _create_model_target_web_api_client_credentials(
     credential_name: str,
 ) -> _ModelTargetWebAPIClientCredentials:
     """Create OAuth2 client credentials for the Model Target Web API."""
-    user_id = _strings_from_json_request_in_browser(
+    logged_in_user = _json_request_in_browser(
         driver=driver,
         url=(
             "https://developer.vuforia.com"
             "/targetmanager/vuforiaUtil/getLoggedInUser"
         ),
-        key_groups=(("eguid", "eGuid", "userId", "user_id"),),
-    )[0]
+    )
+    user_id = _string_from_json(
+        value=logged_in_user,
+        keys=("eguid", "eGuid", "userId", "user_id"),
+    )
 
-    access_token = _strings_from_json_request_in_browser(
+    access_token_response = _json_request_in_browser(
         driver=driver,
         url=(
             "https://developer.vuforia.com"
@@ -1075,10 +1079,13 @@ def _create_model_target_web_api_client_credentials(
             "userId": user_id,
             "scopes": [_OAUTH2_CLIENT_CREDENTIALS_SCOPE],
         },
-        key_groups=(("access_token", "accessToken"),),
-    )[0]
+    )
+    access_token = _string_from_json(
+        value=access_token_response,
+        keys=("access_token", "accessToken"),
+    )
 
-    credentials = _strings_from_json_request_in_browser(
+    credentials_response = _json_request_in_browser(
         driver=driver,
         url="https://vws.vuforia.com/oauth2/clientcredentials",
         data={
@@ -1086,52 +1093,73 @@ def _create_model_target_web_api_client_credentials(
             "scopes": list(_MODEL_TARGET_WEB_API_SCOPES),
         },
         access_token=access_token,
-        key_groups=(
-            ("client_id", "clientId"),
-            ("client_secret", "clientSecret"),
-        ),
+    )
+    client_id = _string_from_json(
+        value=credentials_response,
+        keys=("client_id", "clientId"),
+    )
+    client_secret = _string_from_json(
+        value=credentials_response,
+        keys=("client_secret", "clientSecret"),
     )
     return _ModelTargetWebAPIClientCredentials(
-        client_id=credentials[0],
-        client_secret=credentials[1],
+        client_id=client_id,
+        client_secret=client_secret,
     )
 
 
 @beartype
-def _strings_from_json_request_in_browser(
+def _is_json_object(value: object, /) -> TypeGuard[dict[object, object]]:
+    """Return whether value is a JSON object."""
+    return isinstance(value, dict)
+
+
+@beartype
+def _is_json_array(value: object, /) -> TypeGuard[list[object]]:
+    """Return whether value is a JSON array."""
+    return isinstance(value, list)
+
+
+@beartype
+def _string_from_json(
+    *,
+    value: object,
+    keys: tuple[str, ...],
+) -> str:
+    """Find a non-empty string in a JSON-like value."""
+    if _is_json_object(value):
+        for key in keys:
+            child = value.get(key)
+            if isinstance(child, str) and child:
+                return child
+        for child in value.values():
+            with contextlib.suppress(ValueError):
+                return _string_from_json(value=child, keys=keys)
+
+    if _is_json_array(value):
+        for child in value:
+            with contextlib.suppress(ValueError):
+                return _string_from_json(value=child, keys=keys)
+
+    message = f"Response did not include any of: {keys}"
+    raise ValueError(message)
+
+
+@beartype
+def _json_request_in_browser(
     *,
     driver: WebDriver,
     url: str,
-    key_groups: tuple[tuple[str, ...], ...],
     data: dict[str, object] | None = None,
     access_token: str | None = None,
-) -> tuple[str, ...]:
-    """Make a JSON request and extract string values in the browser."""
+) -> object:
+    """Make a JSON request in the browser and return the response body."""
     script_response = driver.execute_async_script(  # pyright: ignore[reportUnknownMemberType]
         """
         const url = arguments[0];
         const data = arguments[1];
         const accessToken = arguments[2];
-        const keyGroups = arguments[3];
         const done = arguments[arguments.length - 1];
-
-        const findString = (value, keys) => {
-            if (!value || typeof value !== "object") {
-                return null;
-            }
-            for (const key of keys) {
-                if (typeof value[key] === "string" && value[key]) {
-                    return value[key];
-                }
-            }
-            for (const child of Object.values(value)) {
-                const found = findString(child, keys);
-                if (found) {
-                    return found;
-                }
-            }
-            return null;
-        };
 
         (async () => {
             try {
@@ -1157,17 +1185,7 @@ def _strings_from_json_request_in_browser(
                     );
                 }
                 const body = text ? JSON.parse(text) : null;
-                const values = [];
-                for (const keys of keyGroups) {
-                    const value = findString(body, keys);
-                    if (!value) {
-                        throw new Error(
-                            `Response did not include any of: ${keys}`,
-                        );
-                    }
-                    values.push(value);
-                }
-                done(`OK\\n${values.join("\\n")}`);
+                done(`OK\\n${JSON.stringify(body)}`);
             } catch (error) {
                 const message =
                     error && error.stack ? error.stack : String(error);
@@ -1178,7 +1196,6 @@ def _strings_from_json_request_in_browser(
         url,
         data,
         access_token,
-        [list(keys) for keys in key_groups],
     )
 
     if not isinstance(script_response, str):
@@ -1196,15 +1213,13 @@ def _strings_from_json_request_in_browser(
             "The Vuforia credentials script returned an unexpected response."
         )
         raise RuntimeError(message)
-    if not payload:
-        message = "The Vuforia credentials response had an unexpected shape."
-        raise RuntimeError(message)
 
-    values = tuple(payload.split(sep="\n"))
-    if len(values) != len(key_groups) or not all(values):
+    try:
+        response_body: object = json.loads(s=payload)
+    except json.JSONDecodeError as exc:
         message = "The Vuforia credentials response had an unexpected shape."
-        raise RuntimeError(message)
-    return values
+        raise RuntimeError(message) from exc
+    return response_body
 
 
 @_TIMEOUT_RETRY_DECORATOR

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1121,7 +1121,6 @@ def _requests_session_from_driver(
 ) -> requests.Session:
     """Create a requests session using the browser's authenticated cookies."""
     session = requests.Session()
-    # This ignore can be removed after Selenium releases script result typing:
     # https://github.com/SeleniumHQ/selenium/pull/17536
     user_agent = driver.execute_script(  # pyright: ignore[reportUnknownMemberType]
         "return navigator.userAgent",
@@ -1129,7 +1128,6 @@ def _requests_session_from_driver(
     if isinstance(user_agent, str):
         session.headers.update({"User-Agent": user_agent})
 
-    # This ignore can be removed after Selenium cookie typing is released:
     # https://github.com/SeleniumHQ/selenium/pull/17537
     raw_cookies: Any = driver.get_cookies()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     cookies: object = raw_cookies

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -3,6 +3,7 @@
 import contextlib
 import datetime
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict
 from urllib.parse import urlparse
@@ -39,6 +40,7 @@ _MODEL_TARGET_WEB_API_CAD_DATA_URL = (
     "2.0/Duck/glTF-Binary/Duck.glb"
 )
 _MODEL_TARGET_WEB_API_SCOPES = ("modeltargets.standardmodeltarget.all",)
+_OAUTH2_CLIENT_CREDENTIALS_SCOPE = "oauth2.clientcredentials.all"
 
 _TIMEOUT_RETRY_DECORATOR = retry(
     retry=retry_if_exception_type(
@@ -100,6 +102,15 @@ class ModelTargetWebAPIDict(TypedDict):
     client_id: str
     client_secret: str
     cad_data_url: str
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class _ModelTargetWebAPIClientCredentials:
+    """Model Target Web API client credentials."""
+
+    client_id: str
+    client_secret: str
 
 
 @beartype
@@ -1043,52 +1054,78 @@ def _create_model_target_web_api_client_credentials(
     *,
     driver: WebDriver,
     credential_name: str,
-) -> tuple[str, str]:
+) -> _ModelTargetWebAPIClientCredentials:
     """Create OAuth2 client credentials for the Model Target Web API."""
+    user_id = _strings_from_json_request_in_browser(
+        driver=driver,
+        url=(
+            "https://developer.vuforia.com"
+            "/targetmanager/vuforiaUtil/getLoggedInUser"
+        ),
+        key_groups=(("eguid", "eGuid", "userId", "user_id"),),
+    )[0]
+
+    access_token = _strings_from_json_request_in_browser(
+        driver=driver,
+        url=(
+            "https://developer.vuforia.com"
+            "/targetmanager/oauth2/credentials/accessToken"
+        ),
+        data={
+            "userId": user_id,
+            "scopes": [_OAUTH2_CLIENT_CREDENTIALS_SCOPE],
+        },
+        key_groups=(("access_token", "accessToken"),),
+    )[0]
+
+    credentials = _strings_from_json_request_in_browser(
+        driver=driver,
+        url="https://vws.vuforia.com/oauth2/clientcredentials",
+        data={
+            "name": credential_name,
+            "scopes": list(_MODEL_TARGET_WEB_API_SCOPES),
+        },
+        access_token=access_token,
+        key_groups=(
+            ("client_id", "clientId"),
+            ("client_secret", "clientSecret"),
+        ),
+    )
+    return _ModelTargetWebAPIClientCredentials(
+        client_id=credentials[0],
+        client_secret=credentials[1],
+    )
+
+
+@beartype
+def _strings_from_json_request_in_browser(
+    *,
+    driver: WebDriver,
+    url: str,
+    key_groups: tuple[tuple[str, ...], ...],
+    data: dict[str, object] | None = None,
+    access_token: str | None = None,
+) -> tuple[str, ...]:
+    """Make a JSON request and extract string values in the browser."""
     script_response = driver.execute_async_script(  # pyright: ignore[reportUnknownMemberType]
         """
-        const credentialName = arguments[0];
-        const scopes = arguments[1];
+        const url = arguments[0];
+        const data = arguments[1];
+        const accessToken = arguments[2];
+        const keyGroups = arguments[3];
         const done = arguments[arguments.length - 1];
 
-        const jsonRequest = async (url, options = {}) => {
-            const response = await fetch(url, {
-                credentials: "include",
-                ...options,
-                headers: {
-                    "Content-Type": "application/json",
-                    "Cache-Control": "no-cache, no-store, must-revalidate",
-                    "Pragma": "no-cache",
-                    "Expires": "0",
-                    ...(options.headers || {}),
-                },
-            });
-            const text = await response.text();
-            let body = null;
-            if (text) {
-                try {
-                    body = JSON.parse(text);
-                } catch {
-                    body = text;
-                }
-            }
-            if (!response.ok) {
-                throw new Error(
-                    `${url} returned HTTP ${response.status}: ${text}`,
-                );
-            }
-            return body;
-        };
-
-        const findString = (value, key) => {
+        const findString = (value, keys) => {
             if (!value || typeof value !== "object") {
                 return null;
             }
-            if (typeof value[key] === "string" && value[key]) {
-                return value[key];
+            for (const key of keys) {
+                if (typeof value[key] === "string" && value[key]) {
+                    return value[key];
+                }
             }
             for (const child of Object.values(value)) {
-                const found = findString(child, key);
+                const found = findString(child, keys);
                 if (found) {
                     return found;
                 }
@@ -1098,67 +1135,39 @@ def _create_model_target_web_api_client_credentials(
 
         (async () => {
             try {
-                const user = await jsonRequest(
-                    "/targetmanager/vuforiaUtil/getLoggedInUser",
-                );
-                const userId =
-                    findString(user, "eguid") ||
-                    findString(user, "eGuid") ||
-                    findString(user, "userId") ||
-                    findString(user, "user_id");
-                if (!userId) {
+                const headers = {
+                    "Content-Type": "application/json",
+                    "Cache-Control": "no-cache, no-store, must-revalidate",
+                    "Pragma": "no-cache",
+                    "Expires": "0",
+                };
+                if (accessToken) {
+                    headers.Authorization = `Bearer ${accessToken}`;
+                }
+                const response = await fetch(url, {
+                    method: data === null ? "GET" : "POST",
+                    credentials: accessToken ? "omit" : "include",
+                    headers,
+                    body: data === null ? undefined : JSON.stringify(data),
+                });
+                const text = await response.text();
+                if (!response.ok) {
                     throw new Error(
-                        "Could not find the logged-in Vuforia user ID.",
+                        `${url} returned HTTP ${response.status}: ${text}`,
                     );
                 }
-
-                const tokenResponse = await jsonRequest(
-                    "/targetmanager/oauth2/credentials/accessToken",
-                    {
-                        method: "POST",
-                        body: JSON.stringify({
-                            userId,
-                            scopes: ["oauth2.clientcredentials.all"],
-                        }),
-                    },
-                );
-                const accessToken =
-                    findString(tokenResponse, "access_token") ||
-                    findString(tokenResponse, "accessToken");
-                if (!accessToken) {
-                    throw new Error(
-                        "Could not get a Vuforia OAuth management token.",
-                    );
+                const body = text ? JSON.parse(text) : null;
+                const values = [];
+                for (const keys of keyGroups) {
+                    const value = findString(body, keys);
+                    if (!value) {
+                        throw new Error(
+                            `Response did not include any of: ${keys}`,
+                        );
+                    }
+                    values.push(value);
                 }
-
-                const credentials = await jsonRequest(
-                    "https://vws.vuforia.com/oauth2/clientcredentials",
-                    {
-                        method: "POST",
-                        credentials: "omit",
-                        headers: {
-                            "Authorization": `Bearer ${accessToken}`,
-                        },
-                        body: JSON.stringify({
-                            name: credentialName,
-                            scopes,
-                        }),
-                    },
-                );
-                const clientId =
-                    findString(credentials, "client_id") ||
-                    findString(credentials, "clientId");
-                const clientSecret =
-                    findString(credentials, "client_secret") ||
-                    findString(credentials, "clientSecret");
-                if (!clientId || !clientSecret) {
-                    throw new Error(
-                        "The Vuforia credentials response did not include " +
-                        "a client ID and client secret.",
-                    );
-                }
-
-                done(`OK\\n${clientId}\\n${clientSecret}`);
+                done(`OK\\n${values.join("\\n")}`);
             } catch (error) {
                 const message =
                     error && error.stack ? error.stack : String(error);
@@ -1166,8 +1175,10 @@ def _create_model_target_web_api_client_credentials(
             }
         })();
         """,
-        credential_name,
-        list(_MODEL_TARGET_WEB_API_SCOPES),
+        url,
+        data,
+        access_token,
+        [list(keys) for keys in key_groups],
     )
 
     if not isinstance(script_response, str):
@@ -1178,22 +1189,22 @@ def _create_model_target_web_api_client_credentials(
 
     status, separator, payload = script_response.partition("\n")
     if status == "ERROR":
-        message = (
-            f"Could not create Model Target Web API credentials: {payload}"
-        )
+        message = f"Could not call the Vuforia credentials API: {payload}"
         raise RuntimeError(message)
     if status != "OK" or not separator:
         message = (
             "The Vuforia credentials script returned an unexpected response."
         )
         raise RuntimeError(message)
-
-    client_id, separator, client_secret = payload.partition("\n")
-    if not client_id or not separator or not client_secret:
+    if not payload:
         message = "The Vuforia credentials response had an unexpected shape."
         raise RuntimeError(message)
 
-    return client_id, client_secret
+    values = tuple(payload.split(sep="\n"))
+    if len(values) != len(key_groups) or not all(values):
+        message = "The Vuforia credentials response had an unexpected shape."
+        raise RuntimeError(message)
+    return values
 
 
 @_TIMEOUT_RETRY_DECORATOR
@@ -1210,14 +1221,14 @@ def get_model_target_web_api_details(
         "vws-web-tools-model-target-web-api-"
         f"{datetime.datetime.now(tz=datetime.UTC):%Y-%m-%d-%H-%M-%S}"
     )
-    client_id, client_secret = _create_model_target_web_api_client_credentials(
+    credentials = _create_model_target_web_api_client_credentials(
         driver=driver,
         credential_name=credential_name,
     )
 
     return {
-        "client_id": client_id,
-        "client_secret": client_secret,
+        "client_id": credentials.client_id,
+        "client_secret": credentials.client_secret,
         "cad_data_url": _MODEL_TARGET_WEB_API_CAD_DATA_URL,
     }
 

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1,6 +1,7 @@
 """Tools for interacting with the VWS (Vuforia Web Services) website."""
 
 import contextlib
+import datetime
 import logging
 from pathlib import Path
 from typing import TypedDict
@@ -31,6 +32,13 @@ from tenacity import (
 )
 
 LOGGER = logging.getLogger(name=__name__)
+
+_MODEL_TARGET_WEB_API_CAD_DATA_URL = (
+    "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/"
+    "d7a3cc8e51d7c573771ae77a57f16b0662a905c6/"
+    "2.0/Duck/glTF-Binary/Duck.glb"
+)
+_MODEL_TARGET_WEB_API_SCOPES = ("modeltargets.standardmodeltarget.all",)
 
 _TIMEOUT_RETRY_DECORATOR = retry(
     retry=retry_if_exception_type(
@@ -83,6 +91,15 @@ class LicenseDict(TypedDict):
 
     license_name: str
     license_key: str
+
+
+@beartype
+class ModelTargetWebAPIDict(TypedDict):
+    """A dictionary type which represents Model Target Web API details."""
+
+    client_id: str
+    client_secret: str
+    cad_data_url: str
 
 
 @beartype
@@ -1018,6 +1035,190 @@ def get_vumark_database_details(
         "database_name": database_name,
         "server_access_key": server_access_key,
         "server_secret_key": server_secret_key,
+    }
+
+
+@beartype
+def _create_model_target_web_api_client_credentials(
+    *,
+    driver: WebDriver,
+    credential_name: str,
+) -> tuple[str, str]:
+    """Create OAuth2 client credentials for the Model Target Web API."""
+    script_response = driver.execute_async_script(  # pyright: ignore[reportUnknownMemberType]
+        """
+        const credentialName = arguments[0];
+        const scopes = arguments[1];
+        const done = arguments[arguments.length - 1];
+
+        const jsonRequest = async (url, options = {}) => {
+            const response = await fetch(url, {
+                credentials: "include",
+                ...options,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Cache-Control": "no-cache, no-store, must-revalidate",
+                    "Pragma": "no-cache",
+                    "Expires": "0",
+                    ...(options.headers || {}),
+                },
+            });
+            const text = await response.text();
+            let body = null;
+            if (text) {
+                try {
+                    body = JSON.parse(text);
+                } catch {
+                    body = text;
+                }
+            }
+            if (!response.ok) {
+                throw new Error(
+                    `${url} returned HTTP ${response.status}: ${text}`,
+                );
+            }
+            return body;
+        };
+
+        const findString = (value, key) => {
+            if (!value || typeof value !== "object") {
+                return null;
+            }
+            if (typeof value[key] === "string" && value[key]) {
+                return value[key];
+            }
+            for (const child of Object.values(value)) {
+                const found = findString(child, key);
+                if (found) {
+                    return found;
+                }
+            }
+            return null;
+        };
+
+        (async () => {
+            try {
+                const user = await jsonRequest(
+                    "/targetmanager/vuforiaUtil/getLoggedInUser",
+                );
+                const userId =
+                    findString(user, "eguid") ||
+                    findString(user, "eGuid") ||
+                    findString(user, "userId") ||
+                    findString(user, "user_id");
+                if (!userId) {
+                    throw new Error(
+                        "Could not find the logged-in Vuforia user ID.",
+                    );
+                }
+
+                const tokenResponse = await jsonRequest(
+                    "/targetmanager/oauth2/credentials/accessToken",
+                    {
+                        method: "POST",
+                        body: JSON.stringify({
+                            userId,
+                            scopes: ["oauth2.clientcredentials.all"],
+                        }),
+                    },
+                );
+                const accessToken =
+                    findString(tokenResponse, "access_token") ||
+                    findString(tokenResponse, "accessToken");
+                if (!accessToken) {
+                    throw new Error(
+                        "Could not get a Vuforia OAuth management token.",
+                    );
+                }
+
+                const credentials = await jsonRequest(
+                    "https://vws.vuforia.com/oauth2/clientcredentials",
+                    {
+                        method: "POST",
+                        credentials: "omit",
+                        headers: {
+                            "Authorization": `Bearer ${accessToken}`,
+                        },
+                        body: JSON.stringify({
+                            name: credentialName,
+                            scopes,
+                        }),
+                    },
+                );
+                const clientId =
+                    findString(credentials, "client_id") ||
+                    findString(credentials, "clientId");
+                const clientSecret =
+                    findString(credentials, "client_secret") ||
+                    findString(credentials, "clientSecret");
+                if (!clientId || !clientSecret) {
+                    throw new Error(
+                        "The Vuforia credentials response did not include " +
+                        "a client ID and client secret.",
+                    );
+                }
+
+                done(`OK\\n${clientId}\\n${clientSecret}`);
+            } catch (error) {
+                const message =
+                    error && error.stack ? error.stack : String(error);
+                done(`ERROR\\n${message}`);
+            }
+        })();
+        """,
+        credential_name,
+        list(_MODEL_TARGET_WEB_API_SCOPES),
+    )
+
+    if not isinstance(script_response, str):
+        message = (
+            "The Vuforia credentials script returned an unexpected response."
+        )
+        raise TypeError(message)
+
+    status, separator, payload = script_response.partition("\n")
+    if status == "ERROR":
+        message = (
+            f"Could not create Model Target Web API credentials: {payload}"
+        )
+        raise RuntimeError(message)
+    if status != "OK" or not separator:
+        message = (
+            "The Vuforia credentials script returned an unexpected response."
+        )
+        raise RuntimeError(message)
+
+    client_id, separator, client_secret = payload.partition("\n")
+    if not client_id or not separator or not client_secret:
+        message = "The Vuforia credentials response had an unexpected shape."
+        raise RuntimeError(message)
+
+    return client_id, client_secret
+
+
+@_TIMEOUT_RETRY_DECORATOR
+@beartype
+def get_model_target_web_api_details(
+    *,
+    driver: WebDriver,
+) -> ModelTargetWebAPIDict:
+    """Get Model Target Web API credentials and a CAD data URL."""
+    driver.get(url="https://developer.vuforia.com/develop/credentials")
+    wait_for_logged_in(driver=driver)
+
+    credential_name = (
+        "vws-web-tools-model-target-web-api-"
+        f"{datetime.datetime.now(tz=datetime.UTC):%Y-%m-%d-%H-%M-%S}"
+    )
+    client_id, client_secret = _create_model_target_web_api_client_credentials(
+        driver=driver,
+        credential_name=credential_name,
+    )
+
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "cad_data_url": _MODEL_TARGET_WEB_API_CAD_DATA_URL,
     }
 
 

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -2,14 +2,14 @@
 
 import contextlib
 import datetime
-import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, TypeGuard
+from typing import Any, TypedDict, TypeGuard
 from urllib.parse import urlparse
 
 import click
+import requests
 import yaml
 from beartype import beartype
 from selenium.common.exceptions import (
@@ -42,6 +42,7 @@ _MODEL_TARGET_WEB_API_CAD_DATA_URL = (
 )
 _MODEL_TARGET_WEB_API_SCOPES = ("modeltargets.standardmodeltarget.all",)
 _OAUTH2_CLIENT_CREDENTIALS_SCOPE = "oauth2.clientcredentials.all"
+_REQUEST_TIMEOUT_SECONDS = 30
 
 _TIMEOUT_RETRY_DECORATOR = retry(
     retry=retry_if_exception_type(
@@ -1057,8 +1058,11 @@ def _create_model_target_web_api_client_credentials(
     credential_name: str,
 ) -> _ModelTargetWebAPIClientCredentials:
     """Create OAuth2 client credentials for the Model Target Web API."""
-    logged_in_user = _json_request_in_browser(
-        driver=driver,
+    session = _requests_session_from_driver(driver=driver)
+
+    logged_in_user = _json_request(
+        session=session,
+        method="GET",
         url=(
             "https://developer.vuforia.com"
             "/targetmanager/vuforiaUtil/getLoggedInUser"
@@ -1069,8 +1073,9 @@ def _create_model_target_web_api_client_credentials(
         keys=("eguid", "eGuid", "userId", "user_id"),
     )
 
-    access_token_response = _json_request_in_browser(
-        driver=driver,
+    access_token_response = _json_request(
+        session=session,
+        method="POST",
         url=(
             "https://developer.vuforia.com"
             "/targetmanager/oauth2/credentials/accessToken"
@@ -1085,8 +1090,9 @@ def _create_model_target_web_api_client_credentials(
         keys=("access_token", "accessToken"),
     )
 
-    credentials_response = _json_request_in_browser(
-        driver=driver,
+    credentials_response = _json_request(
+        session=session,
+        method="POST",
         url="https://vws.vuforia.com/oauth2/clientcredentials",
         data={
             "name": credential_name,
@@ -1106,6 +1112,44 @@ def _create_model_target_web_api_client_credentials(
         client_id=client_id,
         client_secret=client_secret,
     )
+
+
+@beartype
+def _requests_session_from_driver(
+    *,
+    driver: WebDriver,
+) -> requests.Session:
+    """Create a requests session using the browser's authenticated cookies."""
+    session = requests.Session()
+    user_agent = driver.execute_script(  # pyright: ignore[reportUnknownMemberType]
+        "return navigator.userAgent",
+    )
+    if isinstance(user_agent, str):
+        session.headers.update({"User-Agent": user_agent})
+
+    raw_cookies: Any = driver.get_cookies()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    cookies: object = raw_cookies
+    if not _is_json_array(cookies):
+        return session
+
+    for cookie in cookies:
+        if not _is_json_object(cookie):
+            continue
+        name = cookie.get("name")
+        value = cookie.get("value")
+        if not isinstance(name, str) or not isinstance(value, str):
+            continue
+
+        domain = cookie.get("domain")
+        path = cookie.get("path")
+        session.cookies.set(
+            name=name,
+            value=value,
+            domain=domain if isinstance(domain, str) else None,
+            path=path if isinstance(path, str) else "/",
+        )
+
+    return session
 
 
 @beartype
@@ -1146,77 +1190,43 @@ def _string_from_json(
 
 
 @beartype
-def _json_request_in_browser(
+def _json_request(
     *,
-    driver: WebDriver,
+    session: requests.Session,
+    method: str,
     url: str,
-    data: dict[str, object] | None = None,
+    data: dict[str, str | list[str]] | None = None,
     access_token: str | None = None,
 ) -> object:
-    """Make a JSON request in the browser and return the response body."""
-    script_response = driver.execute_async_script(  # pyright: ignore[reportUnknownMemberType]
-        """
-        const url = arguments[0];
-        const data = arguments[1];
-        const accessToken = arguments[2];
-        const done = arguments[arguments.length - 1];
-
-        (async () => {
-            try {
-                const headers = {
-                    "Content-Type": "application/json",
-                    "Cache-Control": "no-cache, no-store, must-revalidate",
-                    "Pragma": "no-cache",
-                    "Expires": "0",
-                };
-                if (accessToken) {
-                    headers.Authorization = `Bearer ${accessToken}`;
-                }
-                const response = await fetch(url, {
-                    method: data === null ? "GET" : "POST",
-                    credentials: accessToken ? "omit" : "include",
-                    headers,
-                    body: data === null ? undefined : JSON.stringify(data),
-                });
-                const text = await response.text();
-                if (!response.ok) {
-                    throw new Error(
-                        `${url} returned HTTP ${response.status}: ${text}`,
-                    );
-                }
-                const body = text ? JSON.parse(text) : null;
-                done(`OK\\n${JSON.stringify(body)}`);
-            } catch (error) {
-                const message =
-                    error && error.stack ? error.stack : String(error);
-                done(`ERROR\\n${message}`);
-            }
-        })();
-        """,
-        url,
-        data,
-        access_token,
-    )
-
-    if not isinstance(script_response, str):
-        message = (
-            "The Vuforia credentials script returned an unexpected response."
-        )
-        raise TypeError(message)
-
-    status, separator, payload = script_response.partition("\n")
-    if status == "ERROR":
-        message = f"Could not call the Vuforia credentials API: {payload}"
-        raise RuntimeError(message)
-    if status != "OK" or not separator:
-        message = (
-            "The Vuforia credentials script returned an unexpected response."
-        )
-        raise RuntimeError(message)
+    """Make a JSON request and return the response body."""
+    headers = {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+    }
+    if access_token is not None:
+        headers["Authorization"] = f"Bearer {access_token}"
 
     try:
-        response_body: object = json.loads(s=payload)
-    except json.JSONDecodeError as exc:
+        response = session.request(
+            method=method,
+            url=url,
+            headers=headers,
+            json=data,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        body_excerpt = ""
+        if exc.response is not None:
+            body_excerpt = f": {exc.response.text[:500]}"
+        message = f"Could not call the Vuforia credentials API{body_excerpt}"
+        raise RuntimeError(message) from exc
+
+    try:
+        response_body: object = response.json()
+    except requests.JSONDecodeError as exc:
         message = "The Vuforia credentials response had an unexpected shape."
         raise RuntimeError(message) from exc
     return response_body

--- a/tests/test_create_database.py
+++ b/tests/test_create_database.py
@@ -518,6 +518,24 @@ def test_get_license_details_library(
     assert details["license_key"]
 
 
+def test_get_model_target_web_api_details_library(
+    *,
+    logged_in_chrome_driver: WebDriver,
+) -> None:
+    """Test getting Model Target Web API details via the library."""
+    details = vws_web_tools.get_model_target_web_api_details(
+        driver=logged_in_chrome_driver,
+    )
+
+    assert details["client_id"]
+    assert details["client_secret"]
+    assert details["cad_data_url"] == (
+        "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/"
+        "d7a3cc8e51d7c573771ae77a57f16b0662a905c6/"
+        "2.0/Duck/glTF-Binary/Duck.glb"
+    )
+
+
 def test_show_license_details_cli(
     *,
     vws_credentials: VWSCredentials,

--- a/tests/test_model_target_web_api_details.py
+++ b/tests/test_model_target_web_api_details.py
@@ -1,0 +1,241 @@
+# pyright: reportPrivateUsage=false
+# pylint: disable=protected-access,super-init-not-called
+# ruff: noqa: ANN401, SLF001
+"""Tests for Model Target Web API detail helpers."""
+
+from typing import Any
+
+import pytest
+import requests
+from selenium.webdriver.remote.webdriver import WebDriver
+
+import vws_web_tools
+
+
+class _BrowserStateDriver(WebDriver):
+    """A WebDriver shell with controlled browser state."""
+
+    def __init__(
+        self,
+        *,
+        user_agent: object,
+        cookies: object,
+    ) -> None:
+        """Store controlled browser state."""
+        self._user_agent = user_agent
+        self._cookies = cookies
+
+    def execute_script(self, script: str, *args: object) -> object:
+        """Return the controlled user agent."""
+        assert script == "return navigator.userAgent"
+        assert not args
+        return self._user_agent
+
+    def get_cookies(self) -> Any:
+        """Return the controlled cookies."""
+        return self._cookies
+
+
+def test_requests_session_from_driver_copies_browser_state() -> None:
+    """Cookies and the user agent are copied into a requests session."""
+    driver = _BrowserStateDriver(
+        user_agent="test browser",
+        cookies=[
+            {
+                "name": "session",
+                "value": "abc",
+                "domain": "example.com",
+                "path": "/developer",
+            },
+            {"name": "host", "value": "only"},
+            {"name": "bad-value", "value": 123},
+            "not a cookie",
+        ],
+    )
+
+    session = vws_web_tools._requests_session_from_driver(driver=driver)
+
+    assert session.headers["User-Agent"] == "test browser"
+    assert session.cookies.get(name="session", domain="example.com") == "abc"
+    assert session.cookies.get(name="host") == "only"
+    assert session.cookies.get(name="bad-value") is None
+
+
+@pytest.mark.parametrize(
+    argnames=("user_agent", "cookies"),
+    argvalues=[
+        (None, []),
+        ("test browser", "not a cookie list"),
+    ],
+)
+def test_requests_session_from_driver_handles_unexpected_browser_state(
+    *,
+    user_agent: object,
+    cookies: object,
+) -> None:
+    """Unexpected browser state is ignored."""
+    driver = _BrowserStateDriver(
+        user_agent=user_agent,
+        cookies=cookies,
+    )
+
+    session = vws_web_tools._requests_session_from_driver(driver=driver)
+
+    assert session.headers["User-Agent"] == (
+        user_agent if isinstance(user_agent, str) else "python-requests/2.34.2"
+    )
+    assert not session.cookies
+
+
+def test_string_from_json_finds_nested_values() -> None:
+    """A non-empty matching string is found recursively."""
+    result = vws_web_tools._string_from_json(
+        value={
+            "client_id": "",
+            "nested": [
+                {"clientId": "client-id"},
+            ],
+        },
+        keys=("client_id", "clientId"),
+    )
+
+    assert result == "client-id"
+
+
+def test_string_from_json_raises_for_missing_values() -> None:
+    """A missing matching string raises a useful error."""
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="Response did not include any of",
+    ):
+        vws_web_tools._string_from_json(
+            value={"nested": [None, {"client_id": ""}]},
+            keys=("client_id", "clientId"),
+        )
+
+
+def _response(
+    *,
+    status_code: int = 200,
+    content: bytes = b'{"ok": true}',
+) -> requests.Response:
+    """Return a minimal requests response."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = "https://example.com"
+    response._content = content  # noqa: V101
+    return response
+
+
+class _Session(requests.Session):
+    """A requests session with a controlled response."""
+
+    def __init__(
+        self,
+        *,
+        response: requests.Response,
+    ) -> None:
+        """Store the response returned by the fake session."""
+        super().__init__()
+        self.prepared_request: requests.PreparedRequest | None = None
+        self.send_kwargs: dict[str, object] | None = None
+        self._response = response
+
+    def send(  # noqa: V105
+        self,
+        request: requests.PreparedRequest,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Store the prepared request and return the controlled
+        response.
+        """
+        self.prepared_request = request
+        self.send_kwargs = kwargs
+        return self._response
+
+
+class _FailingSession(requests.Session):
+    """A requests session which fails before receiving a response."""
+
+    def send(  # noqa: V105
+        self,
+        request: requests.PreparedRequest,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Raise a request failure without an HTTP response."""
+        assert request.url == "https://example.com/"
+        assert kwargs["timeout"] == vws_web_tools._REQUEST_TIMEOUT_SECONDS
+        raise requests.ConnectionError
+
+
+def test_json_request_sends_json_headers_and_returns_response_body() -> None:
+    """JSON requests include headers, payloads, and access tokens."""
+    session = _Session(response=_response())
+
+    response = vws_web_tools._json_request(
+        session=session,
+        method="POST",
+        url="https://example.com",
+        data={"name": "credential", "scopes": ["scope"]},
+        access_token="test-access-token",  # noqa: S106
+    )
+
+    assert response == {"ok": True}
+    assert session.prepared_request is not None
+    assert session.prepared_request.method == "POST"
+    assert session.prepared_request.body == (
+        b'{"name": "credential", "scopes": ["scope"]}'
+    )
+    assert (
+        session.prepared_request.headers["Authorization"]
+        == "Bearer test-access-token"
+    )
+    assert session.send_kwargs is not None
+    assert (
+        session.send_kwargs["timeout"]
+        == vws_web_tools._REQUEST_TIMEOUT_SECONDS
+    )
+
+
+def test_json_request_raises_runtime_error_for_request_failure() -> None:
+    """Request failures include a response body excerpt."""
+    session = _Session(
+        response=_response(
+            status_code=500,
+            content=b"response body",
+        ),
+    )
+
+    with pytest.raises(expected_exception=RuntimeError, match="response body"):
+        vws_web_tools._json_request(
+            session=session,
+            method="GET",
+            url="https://example.com",
+        )
+
+
+def test_json_request_raises_runtime_error_for_connection_failure() -> None:
+    """Connection failures raise a stable runtime error."""
+    with pytest.raises(
+        expected_exception=RuntimeError,
+        match=r"Could not call the Vuforia credentials API$",
+    ):
+        vws_web_tools._json_request(
+            session=_FailingSession(),
+            method="GET",
+            url="https://example.com",
+        )
+
+
+def test_json_request_raises_runtime_error_for_invalid_json() -> None:
+    """Invalid JSON responses raise a stable runtime error."""
+    session = _Session(response=_response(content=b"not json"))
+
+    with pytest.raises(
+        expected_exception=RuntimeError, match="unexpected shape"
+    ):
+        vws_web_tools._json_request(
+            session=session,
+            method="GET",
+            url="https://example.com",
+        )


### PR DESCRIPTION
Adds `get_model_target_web_api_details(driver=...)` so downstream secret generation can create Model Target Web API OAuth credentials from an existing Vuforia developer portal session. The helper returns `client_id`, `client_secret`, and a pinned small CAD model URL suitable for standard Model Target API tests. It also adds a news fragment and a narrow Vulture ignore for this downstream-used public API. Validated with the pre-commit hook suite during commit/push, plus `ruff`, `pyright`, `mypy`, `vulture .`, and `pytest tests/test_help.py`.