### PR TITLE
Clean up Model Target credentials in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,6 +385,7 @@ ignore_names = [
     "pytest_plugins",
     # public API used by downstream secret generation
     "cad_data_url",
+    "delete_model_target_web_api_client_credentials",
     "get_model_target_web_api_details",
     "MODEL_TARGET_WEB_API_ADVANCED_SCOPE",
     "MODEL_TARGET_WEB_API_ADVANCED_SCOPES",

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1314,7 +1314,7 @@ def _request(
         if exc.response is not None:
             body_excerpt = f": {exc.response.text[:500]}"
         message = f"Could not call the Vuforia credentials API{body_excerpt}"
-        raise RuntimeError(message) from exc
+        raise RuntimeError(message) from None
     return response
 
 

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -3,11 +3,12 @@
 import contextlib
 import datetime
 import logging
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypedDict, TypeGuard
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import click
 import requests
@@ -1068,6 +1069,64 @@ def _create_model_target_web_api_client_credentials(
     scopes: Sequence[str],
 ) -> _ModelTargetWebAPIClientCredentials:
     """Create OAuth2 client credentials for the Model Target Web API."""
+    session, access_token = _model_target_web_api_credentials_api_session(
+        driver=driver,
+    )
+
+    credentials_response = _json_request(
+        session=session,
+        method="POST",
+        url="https://vws.vuforia.com/oauth2/clientcredentials",
+        data={
+            "name": credential_name,
+            "scopes": list(scopes),
+        },
+        access_token=access_token,
+    )
+    client_id = _string_from_json(
+        value=credentials_response,
+        keys=("client_id", "clientId"),
+    )
+    client_secret = _string_from_json(
+        value=credentials_response,
+        keys=("client_secret", "clientSecret"),
+    )
+    return _ModelTargetWebAPIClientCredentials(
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
+@beartype
+def delete_model_target_web_api_client_credentials(
+    *,
+    driver: WebDriver,
+    client_id: str,
+) -> None:
+    """Delete one OAuth2 client credential by its exact client ID."""
+    driver.get(url="https://developer.vuforia.com/develop/credentials")
+    wait_for_logged_in(driver=driver)
+    session, access_token = _model_target_web_api_credentials_api_session(
+        driver=driver,
+    )
+    encoded_client_id = quote(string=client_id, safe="")
+    _request(
+        session=session,
+        method="DELETE",
+        url=(
+            "https://vws.vuforia.com/oauth2/clientcredentials/"
+            f"{encoded_client_id}"
+        ),
+        access_token=access_token,
+    )
+
+
+@beartype
+def _model_target_web_api_credentials_api_session(
+    *,
+    driver: WebDriver,
+) -> tuple[requests.Session, str]:
+    """Return a session and token for the credentials management API."""
     session = _requests_session_from_driver(driver=driver)
 
     logged_in_user = _json_request(
@@ -1099,29 +1158,7 @@ def _create_model_target_web_api_client_credentials(
         value=access_token_response,
         keys=("access_token", "accessToken"),
     )
-
-    credentials_response = _json_request(
-        session=session,
-        method="POST",
-        url="https://vws.vuforia.com/oauth2/clientcredentials",
-        data={
-            "name": credential_name,
-            "scopes": list(scopes),
-        },
-        access_token=access_token,
-    )
-    client_id = _string_from_json(
-        value=credentials_response,
-        keys=("client_id", "clientId"),
-    )
-    client_secret = _string_from_json(
-        value=credentials_response,
-        keys=("client_secret", "clientSecret"),
-    )
-    return _ModelTargetWebAPIClientCredentials(
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    return session, access_token
 
 
 @beartype
@@ -1215,6 +1252,32 @@ def _json_request(
     access_token: str | None = None,
 ) -> object:
     """Make a JSON request and return the response body."""
+    response = _request(
+        session=session,
+        method=method,
+        url=url,
+        data=data,
+        access_token=access_token,
+    )
+
+    try:
+        response_body: object = response.json()
+    except requests.JSONDecodeError as exc:
+        message = "The Vuforia credentials response had an unexpected shape."
+        raise RuntimeError(message) from exc
+    return response_body
+
+
+@beartype
+def _request(
+    *,
+    session: requests.Session,
+    method: str,
+    url: str,
+    data: dict[str, str | list[str]] | None = None,
+    access_token: str | None = None,
+) -> requests.Response:
+    """Make a request to the Vuforia credentials API."""
     headers = {
         "Content-Type": "application/json",
         "Cache-Control": "no-cache, no-store, must-revalidate",
@@ -1239,13 +1302,7 @@ def _json_request(
             body_excerpt = f": {exc.response.text[:500]}"
         message = f"Could not call the Vuforia credentials API{body_excerpt}"
         raise RuntimeError(message) from exc
-
-    try:
-        response_body: object = response.json()
-    except requests.JSONDecodeError as exc:
-        message = "The Vuforia credentials response had an unexpected shape."
-        raise RuntimeError(message) from exc
-    return response_body
+    return response
 
 
 @_TIMEOUT_RETRY_DECORATOR
@@ -1271,7 +1328,8 @@ def get_model_target_web_api_details(
 
     credential_name = (
         "vws-web-tools-model-target-web-api-"
-        f"{datetime.datetime.now(tz=datetime.UTC):%Y-%m-%d-%H-%M-%S}"
+        f"{datetime.datetime.now(tz=datetime.UTC):%Y-%m-%d-%H-%M-%S}-"
+        f"{uuid.uuid4().hex}"
     )
     credentials = _create_model_target_web_api_client_credentials(
         driver=driver,

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -126,6 +126,15 @@ class _ModelTargetWebAPIClientCredentials:
 
 
 @beartype
+@dataclass(frozen=True, kw_only=True)
+class _ModelTargetWebAPICredentialsAPISession:
+    """Authenticated session for the credentials management API."""
+
+    session: requests.Session
+    access_token: str
+
+
+@beartype
 def _log_in_once(
     *,
     driver: WebDriver,
@@ -1069,19 +1078,19 @@ def _create_model_target_web_api_client_credentials(
     scopes: Sequence[str],
 ) -> _ModelTargetWebAPIClientCredentials:
     """Create OAuth2 client credentials for the Model Target Web API."""
-    session, access_token = _model_target_web_api_credentials_api_session(
+    api_session = _model_target_web_api_credentials_api_session(
         driver=driver,
     )
 
     credentials_response = _json_request(
-        session=session,
+        session=api_session.session,
         method="POST",
         url="https://vws.vuforia.com/oauth2/clientcredentials",
         data={
             "name": credential_name,
             "scopes": list(scopes),
         },
-        access_token=access_token,
+        access_token=api_session.access_token,
     )
     client_id = _string_from_json(
         value=credentials_response,
@@ -1106,18 +1115,18 @@ def delete_model_target_web_api_client_credentials(
     """Delete one OAuth2 client credential by its exact client ID."""
     driver.get(url="https://developer.vuforia.com/develop/credentials")
     wait_for_logged_in(driver=driver)
-    session, access_token = _model_target_web_api_credentials_api_session(
+    api_session = _model_target_web_api_credentials_api_session(
         driver=driver,
     )
     encoded_client_id = quote(string=client_id, safe="")
     _request(
-        session=session,
+        session=api_session.session,
         method="DELETE",
         url=(
             "https://vws.vuforia.com/oauth2/clientcredentials/"
             f"{encoded_client_id}"
         ),
-        access_token=access_token,
+        access_token=api_session.access_token,
     )
 
 
@@ -1125,7 +1134,7 @@ def delete_model_target_web_api_client_credentials(
 def _model_target_web_api_credentials_api_session(
     *,
     driver: WebDriver,
-) -> tuple[requests.Session, str]:
+) -> _ModelTargetWebAPICredentialsAPISession:
     """Return a session and token for the credentials management API."""
     session = _requests_session_from_driver(driver=driver)
 
@@ -1158,7 +1167,10 @@ def _model_target_web_api_credentials_api_session(
         value=access_token_response,
         keys=("access_token", "accessToken"),
     )
-    return session, access_token
+    return _ModelTargetWebAPICredentialsAPISession(
+        session=session,
+        access_token=access_token,
+    )
 
 
 @beartype

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1126,6 +1126,7 @@ def delete_model_target_web_api_client_credentials(
             "https://vws.vuforia.com/oauth2/clientcredentials/"
             f"{encoded_client_id}"
         ),
+        data=None,
         access_token=api_session.access_token,
     )
 
@@ -1286,8 +1287,8 @@ def _request(
     session: requests.Session,
     method: str,
     url: str,
-    data: dict[str, str | list[str]] | None = None,
-    access_token: str | None = None,
+    data: dict[str, str | list[str]] | None,
+    access_token: str | None,
 ) -> requests.Response:
     """Make a request to the Vuforia credentials API."""
     headers = {

--- a/tests/test_create_database.py
+++ b/tests/test_create_database.py
@@ -527,13 +527,19 @@ def test_get_model_target_web_api_details_library(
         driver=logged_in_chrome_driver,
     )
 
-    assert details["client_id"]
-    assert details["client_secret"]
-    assert details["cad_data_url"] == (
-        "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/"
-        "d7a3cc8e51d7c573771ae77a57f16b0662a905c6/"
-        "2.0/Duck/glTF-Binary/Duck.glb"
-    )
+    try:
+        assert details["client_id"]
+        assert details["client_secret"]
+        assert details["cad_data_url"] == (
+            "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/"
+            "d7a3cc8e51d7c573771ae77a57f16b0662a905c6/"
+            "2.0/Duck/glTF-Binary/Duck.glb"
+        )
+    finally:
+        vws_web_tools.delete_model_target_web_api_client_credentials(
+            driver=logged_in_chrome_driver,
+            client_id=details["client_id"],
+        )
 
 
 def test_show_license_details_cli(

--- a/tests/test_model_target_web_api_details.py
+++ b/tests/test_model_target_web_api_details.py
@@ -3,6 +3,7 @@
 # ruff: noqa: ANN401, SLF001
 """Tests for Model Target Web API detail helpers."""
 
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -34,6 +35,18 @@ class _BrowserStateDriver(WebDriver):
     def get_cookies(self) -> Any:
         """Return the controlled cookies."""
         return self._cookies
+
+
+class _NavigationDriver(WebDriver):
+    """A WebDriver shell which records navigation."""
+
+    def __init__(self) -> None:
+        """Create an empty navigation record."""
+        self.requested_urls: list[str] = []
+
+    def get(self, url: str) -> None:
+        """Record a requested URL."""
+        self.requested_urls.append(url)
 
 
 def test_requests_session_from_driver_copies_browser_state() -> None:
@@ -152,6 +165,170 @@ class _Session(requests.Session):
         self.prepared_request = request
         self.send_kwargs = kwargs
         return self._response
+
+
+def test_create_model_target_web_api_client_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Client credentials are created with the requested name and
+    scopes.
+    """
+    driver = _NavigationDriver()
+    session = _Session(
+        response=_response(
+            content=(
+                b'{"clientId": "client-id", "clientSecret": "client-secret"}'
+            ),
+        ),
+    )
+
+    def credentials_api_session(
+        *,
+        driver: WebDriver,
+    ) -> tuple[requests.Session, str]:
+        """Return the controlled authenticated session."""
+        assert driver is not None
+        return session, "access-token"
+
+    monkeypatch.setattr(
+        target=vws_web_tools,
+        name="_model_target_web_api_credentials_api_session",
+        value=credentials_api_session,
+    )
+
+    credentials = (
+        vws_web_tools._create_model_target_web_api_client_credentials(
+            driver=driver,
+            credential_name="credential-name",
+            scopes=("scope-one", "scope-two"),
+        )
+    )
+
+    assert credentials.client_id == "client-id"
+    assert credentials.client_secret == "client-secret"  # noqa: S105
+    assert session.prepared_request is not None
+    assert session.prepared_request.method == "POST"
+    assert session.prepared_request.url == (
+        "https://vws.vuforia.com/oauth2/clientcredentials"
+    )
+    assert session.prepared_request.body == (
+        b'{"name": "credential-name", "scopes": ["scope-one", "scope-two"]}'
+    )
+    assert session.prepared_request.headers["Authorization"] == (
+        "Bearer access-token"
+    )
+
+
+def test_delete_model_target_web_api_client_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the credential with the exact client ID is deleted."""
+    driver = _NavigationDriver()
+    session = _Session(response=_response(status_code=204, content=b""))
+
+    def credentials_api_session(
+        *,
+        driver: WebDriver,
+    ) -> tuple[requests.Session, str]:
+        """Return the controlled authenticated session."""
+        assert driver is not None
+        return session, "access-token"
+
+    def wait_for_logged_in(*, driver: WebDriver) -> None:
+        """Record that login waiting was requested."""
+        assert driver is not None
+
+    monkeypatch.setattr(
+        target=vws_web_tools,
+        name="_model_target_web_api_credentials_api_session",
+        value=credentials_api_session,
+    )
+    monkeypatch.setattr(
+        target=vws_web_tools,
+        name="wait_for_logged_in",
+        value=wait_for_logged_in,
+    )
+
+    vws_web_tools.delete_model_target_web_api_client_credentials(
+        driver=driver,
+        client_id="client/id",
+    )
+
+    assert session.prepared_request is not None
+    assert driver.requested_urls == [
+        "https://developer.vuforia.com/develop/credentials",
+    ]
+    assert session.prepared_request.method == "DELETE"
+    assert session.prepared_request.url == (
+        "https://vws.vuforia.com/oauth2/clientcredentials/client%2Fid"
+    )
+    assert session.prepared_request.body is None
+    assert session.prepared_request.headers["Authorization"] == (
+        "Bearer access-token"
+    )
+
+
+def test_get_model_target_web_api_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Details use unique credential names and the requested scopes."""
+    driver = _NavigationDriver()
+    created_credential_names: list[str] = []
+    created_scopes: list[Sequence[str]] = []
+
+    def wait_for_logged_in(*, driver: WebDriver) -> None:
+        """Record that login waiting was requested."""
+        assert driver is not None
+
+    def create_client_credentials(
+        *,
+        driver: WebDriver,
+        credential_name: str,
+        scopes: Sequence[str],
+    ) -> vws_web_tools._ModelTargetWebAPIClientCredentials:
+        """Record creation inputs and return controlled credentials."""
+        assert driver is not None
+        created_credential_names.append(credential_name)
+        created_scopes.append(scopes)
+        return vws_web_tools._ModelTargetWebAPIClientCredentials(
+            client_id="client-id",
+            client_secret="client-secret",  # noqa: S106
+        )
+
+    monkeypatch.setattr(
+        target=vws_web_tools,
+        name="wait_for_logged_in",
+        value=wait_for_logged_in,
+    )
+    monkeypatch.setattr(
+        target=vws_web_tools,
+        name="_create_model_target_web_api_client_credentials",
+        value=create_client_credentials,
+    )
+
+    details = vws_web_tools.get_model_target_web_api_details(
+        driver=driver,
+        scopes=("scope",),
+    )
+
+    assert driver.requested_urls == [
+        "https://developer.vuforia.com/develop/credentials",
+    ]
+    assert created_scopes == [("scope",)]
+    assert len(created_credential_names) == 1
+    credential_name = created_credential_names[0]
+    assert credential_name.startswith("vws-web-tools-model-target-web-api-")
+    credential_uuid = credential_name.rsplit(sep="-", maxsplit=1)[1]
+    uuid_hex_length = 32
+    assert len(credential_uuid) == uuid_hex_length
+    assert all(
+        character in "0123456789abcdef" for character in credential_uuid
+    )
+    assert details == {
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "cad_data_url": vws_web_tools._MODEL_TARGET_WEB_API_CAD_DATA_URL,
+    }
 
 
 class _FailingSession(requests.Session):

--- a/tests/test_model_target_web_api_details.py
+++ b/tests/test_model_target_web_api_details.py
@@ -219,12 +219,15 @@ def test_json_request_raises_runtime_error_for_connection_failure() -> None:
     with pytest.raises(
         expected_exception=RuntimeError,
         match=r"Could not call the Vuforia credentials API$",
-    ):
+    ) as exc_info:
         vws_web_tools._json_request(
             session=_FailingSession(),
             method="GET",
             url="https://example.com",
         )
+
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__
 
 
 def test_json_request_raises_runtime_error_for_invalid_json() -> None:

--- a/tests/test_model_target_web_api_details.py
+++ b/tests/test_model_target_web_api_details.py
@@ -3,7 +3,6 @@
 # ruff: noqa: ANN401, SLF001
 """Tests for Model Target Web API detail helpers."""
 
-from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -35,18 +34,6 @@ class _BrowserStateDriver(WebDriver):
     def get_cookies(self) -> Any:
         """Return the controlled cookies."""
         return self._cookies
-
-
-class _NavigationDriver(WebDriver):
-    """A WebDriver shell which records navigation."""
-
-    def __init__(self) -> None:
-        """Create an empty navigation record."""
-        self.requested_urls: list[str] = []
-
-    def get(self, url: str) -> None:
-        """Record a requested URL."""
-        self.requested_urls.append(url)
 
 
 def test_requests_session_from_driver_copies_browser_state() -> None:
@@ -165,170 +152,6 @@ class _Session(requests.Session):
         self.prepared_request = request
         self.send_kwargs = kwargs
         return self._response
-
-
-def test_create_model_target_web_api_client_credentials(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Client credentials are created with the requested name and
-    scopes.
-    """
-    driver = _NavigationDriver()
-    session = _Session(
-        response=_response(
-            content=(
-                b'{"clientId": "client-id", "clientSecret": "client-secret"}'
-            ),
-        ),
-    )
-
-    def credentials_api_session(
-        *,
-        driver: WebDriver,
-    ) -> tuple[requests.Session, str]:
-        """Return the controlled authenticated session."""
-        assert driver is not None
-        return session, "access-token"
-
-    monkeypatch.setattr(
-        target=vws_web_tools,
-        name="_model_target_web_api_credentials_api_session",
-        value=credentials_api_session,
-    )
-
-    credentials = (
-        vws_web_tools._create_model_target_web_api_client_credentials(
-            driver=driver,
-            credential_name="credential-name",
-            scopes=("scope-one", "scope-two"),
-        )
-    )
-
-    assert credentials.client_id == "client-id"
-    assert credentials.client_secret == "client-secret"  # noqa: S105
-    assert session.prepared_request is not None
-    assert session.prepared_request.method == "POST"
-    assert session.prepared_request.url == (
-        "https://vws.vuforia.com/oauth2/clientcredentials"
-    )
-    assert session.prepared_request.body == (
-        b'{"name": "credential-name", "scopes": ["scope-one", "scope-two"]}'
-    )
-    assert session.prepared_request.headers["Authorization"] == (
-        "Bearer access-token"
-    )
-
-
-def test_delete_model_target_web_api_client_credentials(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Only the credential with the exact client ID is deleted."""
-    driver = _NavigationDriver()
-    session = _Session(response=_response(status_code=204, content=b""))
-
-    def credentials_api_session(
-        *,
-        driver: WebDriver,
-    ) -> tuple[requests.Session, str]:
-        """Return the controlled authenticated session."""
-        assert driver is not None
-        return session, "access-token"
-
-    def wait_for_logged_in(*, driver: WebDriver) -> None:
-        """Record that login waiting was requested."""
-        assert driver is not None
-
-    monkeypatch.setattr(
-        target=vws_web_tools,
-        name="_model_target_web_api_credentials_api_session",
-        value=credentials_api_session,
-    )
-    monkeypatch.setattr(
-        target=vws_web_tools,
-        name="wait_for_logged_in",
-        value=wait_for_logged_in,
-    )
-
-    vws_web_tools.delete_model_target_web_api_client_credentials(
-        driver=driver,
-        client_id="client/id",
-    )
-
-    assert session.prepared_request is not None
-    assert driver.requested_urls == [
-        "https://developer.vuforia.com/develop/credentials",
-    ]
-    assert session.prepared_request.method == "DELETE"
-    assert session.prepared_request.url == (
-        "https://vws.vuforia.com/oauth2/clientcredentials/client%2Fid"
-    )
-    assert session.prepared_request.body is None
-    assert session.prepared_request.headers["Authorization"] == (
-        "Bearer access-token"
-    )
-
-
-def test_get_model_target_web_api_details(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Details use unique credential names and the requested scopes."""
-    driver = _NavigationDriver()
-    created_credential_names: list[str] = []
-    created_scopes: list[Sequence[str]] = []
-
-    def wait_for_logged_in(*, driver: WebDriver) -> None:
-        """Record that login waiting was requested."""
-        assert driver is not None
-
-    def create_client_credentials(
-        *,
-        driver: WebDriver,
-        credential_name: str,
-        scopes: Sequence[str],
-    ) -> vws_web_tools._ModelTargetWebAPIClientCredentials:
-        """Record creation inputs and return controlled credentials."""
-        assert driver is not None
-        created_credential_names.append(credential_name)
-        created_scopes.append(scopes)
-        return vws_web_tools._ModelTargetWebAPIClientCredentials(
-            client_id="client-id",
-            client_secret="client-secret",  # noqa: S106
-        )
-
-    monkeypatch.setattr(
-        target=vws_web_tools,
-        name="wait_for_logged_in",
-        value=wait_for_logged_in,
-    )
-    monkeypatch.setattr(
-        target=vws_web_tools,
-        name="_create_model_target_web_api_client_credentials",
-        value=create_client_credentials,
-    )
-
-    details = vws_web_tools.get_model_target_web_api_details(
-        driver=driver,
-        scopes=("scope",),
-    )
-
-    assert driver.requested_urls == [
-        "https://developer.vuforia.com/develop/credentials",
-    ]
-    assert created_scopes == [("scope",)]
-    assert len(created_credential_names) == 1
-    credential_name = created_credential_names[0]
-    assert credential_name.startswith("vws-web-tools-model-target-web-api-")
-    credential_uuid = credential_name.rsplit(sep="-", maxsplit=1)[1]
-    uuid_hex_length = 32
-    assert len(credential_uuid) == uuid_hex_length
-    assert all(
-        character in "0123456789abcdef" for character in credential_uuid
-    )
-    assert details == {
-        "client_id": "client-id",
-        "client_secret": "client-secret",
-        "cad_data_url": vws_web_tools._MODEL_TARGET_WEB_API_CAD_DATA_URL,
-    }
 
 
 class _FailingSession(requests.Session):


### PR DESCRIPTION
## Summary

Prevents CI from exhausting the Vuforia Model Target client-credential quota by deleting the exact credential created by the integration test in a `finally` block. Adds a public exact-ID deletion helper, shared authenticated request handling, and UUID-backed credential names for parallel jobs. The root cause was persistent credentials being created by every matrix job and never removed. Validated with 20 focused tests plus the full pre-commit and pre-push suites; credential creation and deletion remain covered by the real Vuforia integration test.
