### PR TITLE
Queue CI runs using shared VWS credentials

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+---
+paths:
+  .github/workflows/ci.yml:
+    # actionlint 1.7.12 predates GitHub Actions' concurrency queue support.
+    ignore: [unexpected key "queue" for "concurrency" section]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
 
 permissions: {}
 
+# The test suite uses one shared VWS account, which does not reliably support
+# concurrent browser sessions from separate workflow runs.
+concurrency:
+  group: vws-ci
+  queue: max
+
 jobs:
   build:
     environment: vws


### PR DESCRIPTION
Serializes CI workflow runs through a shared `vws-ci` concurrency group with `queue: max`, preserving pending runs instead of canceling them.
The ten Dependabot workflows launched roughly 60 concurrent Selenium sessions against one shared VWS account, causing unrelated license and database timeouts.
Adds a narrowly scoped actionlint configuration because the pinned actionlint 1.7.12 predates GitHub's queue syntax.
Validation included the full pre-commit suite, actionlint, zizmor, YAML checks, `git diff --check`, and the lockfile check.
