### PR TITLE
Use prek action with autofix.ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,37 @@
+---
+name: autofix.ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Run fixers
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage pre-commit --no-fail-fast --verbose
+        env:
+          UV_NO_CACHE: '1'
+          UV_PYTHON: 3.14
+
+      - uses: autofix-ci/action@v1.3.4
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
           VWS_EMAIL_ADDRESS: ${{ secrets.VWS_EMAIL_ADDRESS }}
           VWS_PASSWORD: ${{ secrets.VWS_PASSWORD }}
 
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
-
   completion-ci:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,16 +36,14 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
-          --verbose
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage ${{ matrix.hook-stage }} --verbose
         env:
+          UV_NO_CACHE: '1'
           UV_PYTHON: ${{ matrix.python-version }}
-
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
 
   completion-lint:
     needs: build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,47 +3,6 @@ fail_fast: true
 
 .uv_version: &uv_version uv==0.11.7
 
-# We use system Python, with required dependencies specified in pyproject.toml.
-# We therefore cannot use those dependencies in pre-commit CI.
-ci:
-  skip:
-    - actionlint
-    - check-manifest
-    - deptry
-    - doc8
-    - pydocstringformatter
-    - docs
-    - interrogate
-    - interrogate-docs
-    - linkcheck
-    - mypy
-    - mypy-docs
-    - pylint
-    - pyproject-fmt-fix
-    - pyright
-    - pyright-docs
-    - pyright-verifytypes
-    - pyroma
-    - ruff-check-fix
-    - ruff-check-fix-docs
-    - ruff-format-fix
-    - ruff-format-fix-docs
-    - shellcheck
-    - shellcheck-docs
-    - shfmt
-    - shfmt-docs
-    - spelling
-    - sphinx-lint
-    - strict-kwargs-fix
-    - ty
-    - ty-docs
-    - vulture
-    - vulture-docs
-    - yamlfix
-    - zizmor
-    - pyrefly
-    - pyrefly-docs
-
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_install_hook_types: [pre-commit, pre-push]
@@ -137,7 +96,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:


### PR DESCRIPTION
## Summary

- run the existing lint jobs with `j178/prek-action@v3.0.0` and prek 0.4.11
- add a dedicated autofix.ci producer workflow using `autofix-ci/action@v1.3.4`
- remove legacy pre-commit.ci Lite configuration where present
- let Dependabot update hook revisions through its `pre-commit` ecosystem

Both actions use exact release tags rather than commit SHAs, following the agreed rollout policy.

## Validation

- all changed YAML parses successfully
- `actionlint` passes for both changed workflows
- `zizmor` reports no findings for both changed workflows

Part of [adamtheturtle/Coding-Project-TODOs#8](https://github.com/adamtheturtle/Coding-Project-TODOs/issues/8).

## Before merge

- [ ] Install the autofix.ci GitHub App for this repository
- [ ] Confirm autofix commits are produced on a test pull request
- [ ] Remove the pre-commit.ci GitHub App after the replacement is verified
