### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -412,7 +412,7 @@ repos:
           - *uv_version
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -296,6 +296,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -410,9 +420,3 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
-        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -410,3 +410,9 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pylint[spelling]==4.0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ lint.unfixable = [
     "ERA001",
 ]
 lint.external = [
+    "NOD",
     # Vulture.
     "V",
 ]
@@ -428,3 +429,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/src/vws_web_tools/__init__.py
+++ b/src/vws_web_tools/__init__.py
@@ -1261,8 +1261,8 @@ def _json_request(
     session: requests.Session,
     method: str,
     url: str,
-    data: dict[str, str | list[str]] | None = None,
-    access_token: str | None = None,
+    data: dict[str, str | list[str]] | None = None,  # noqa: NOD001
+    access_token: str | None = None,  # noqa: NOD001
 ) -> object:
     """Make a JSON request and return the response body."""
     response = _request(

--- a/tests/test_model_target_web_api_details.py
+++ b/tests/test_model_target_web_api_details.py
@@ -116,8 +116,8 @@ def test_string_from_json_raises_for_missing_values() -> None:
 
 def _response(
     *,
-    status_code: int = 200,
-    content: bytes = b'{"ok": true}',
+    status_code: int = 200,  # noqa: NOD001
+    content: bytes = b'{"ok": true}',  # noqa: NOD001
 ) -> requests.Response:
     """Return a minimal requests response."""
     response = requests.Response()


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.