### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
+    "beartype==0.23.0rc0",
     "click>=8.1.7",
     "pyyaml>=6.0.2",
     "requests>=2.34.2",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.